### PR TITLE
Mock server calls

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/main.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/main.js
@@ -18,6 +18,52 @@ $(function() {
     if ((window.location.hostname !== "localhost") && (window.location.hostname !== "127.0.0.1")) {
         document.title = document.title+" : "+window.location.hostname;
     }
+    // ------------------------------------------------------------------
+    // Mock all backend requests so the editor can run in a stateless mode
+    // ------------------------------------------------------------------
+    (function($) {
+        if (!$) { return; }
+        var oldAjax = $.ajax;
+        $.ajax = function(options) {
+            var url = options && options.url || "";
+            var method = (options && (options.type || options.method)) || "GET";
+            console.warn("Mock AJAX request", method, url, options);
+            alert("Mock AJAX request: " + method + " " + url);
+            var d = $.Deferred();
+            d.resolve({});
+            return d.promise();
+        };
+    })(jQuery);
+
+    (function() {
+        var OldWebSocket = window.WebSocket;
+        function MockWebSocket(url) {
+            this.url = url;
+            this.readyState = MockWebSocket.CLOSED;
+            console.warn("Mock WebSocket connection:", url);
+            alert("Mock WebSocket connection: " + url);
+            var self = this;
+            setTimeout(function() {
+                if (self.onopen) { self.onopen(); }
+            },0);
+        }
+        MockWebSocket.prototype.send = function(data) {
+            console.warn("Mock WebSocket send", data);
+        };
+        MockWebSocket.prototype.close = function() {
+            console.warn("Mock WebSocket close");
+        };
+        MockWebSocket.OPEN = 1;
+        MockWebSocket.CLOSED = 3;
+        window.WebSocket = MockWebSocket;
+    })();
+
+    if (RED && RED.comms && typeof RED.comms.connect === "function") {
+        RED.comms.connect = function() {
+            console.warn("Mock comms.connect called");
+            alert("Mock WebSocket connect invoked");
+        };
+    }
     RED.init({
         apiRootUrl: ""
     });


### PR DESCRIPTION
## Summary
- override $.ajax and WebSocket in main.js
- override RED.comms.connect

## Testing
- `npm test` *(fails: grunt not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850bbea337c8326b4a8d22af693cbe4